### PR TITLE
Support unordered fields

### DIFF
--- a/derive/de.ml
+++ b/derive/de.ml
@@ -58,6 +58,278 @@ let rec deserializer_for_type ~ctxt (core_type : Parsetree.core_type) =
 
 (** implementation *)
 
+(** Deserializes records in different ways. *)
+module Record_deserializer = struct
+  (** Generates the implementation of a deserializer for a given record type (or
+    list of label declarations).
+
+    The outline of the generated code is:
+
+      * create a field_visitor that maps strings and ints to an ad-hoc field
+        polyvar (field name "hello" matches [`hello])
+
+      * declare field value holders (one 'a option ref per field)
+
+      * create a recursive function for consuimng fields one by one, using
+        the visitor to validate them, and directing the deserialization to the
+        right field deserializer
+
+      * extract the field value holders and validate that all fields are present
+
+      * construct the final result
+
+  So for a record like:
+
+  {ocaml[
+    type person = { name: string; age: int }
+  ]}
+
+  The generated code would look like:
+
+  {ocaml[
+    let deserialize_person = De.(deserializer @@ fun ctx ->
+      record ctx "person" 2 @@ fun ctx ->
+        let field_visitor = Visitor.make
+          ~visit_string:(fun _ctx str ->
+            match str with
+            | "name" -> Ok `name
+            | "age" -> Ok `age
+            | _ -> Error `invalid_field_type)
+          ~visit_int:(fun _ctx int ->
+            match int with
+            | 0 -> Ok `name
+            | 1 -> Ok `age
+            | _ -> Error `invalid_field_type)
+          ()
+        in
+
+        let name = ref None in
+        let age = ref None in
+
+        let rec read_fields () =
+          let* tag = next_field ctx field_visitor in
+          match tag with
+          | Some `name ->
+              let* v = field ctx "name" string in
+              name := Some v;
+              read_fields ()
+          | Some `age ->
+              let* v = field ctx "age" int in
+              age := Some v;
+              read_fields ()
+          | None ->
+              Ok ()
+        in
+        let* () = read_fields () in
+
+        let* name = Option.to_result ~none:(`Msg "missing field 'name'") name in
+        let* age = Option.to_result ~none:(`Msg "missing field 'age'") age in
+
+        Ok {name;age}
+    )
+  ]}
+*)
+  let deserialize_with_unordered_fields ~ctxt labels final_expr =
+    let loc = loc ~ctxt in
+    let labels = List.rev labels in
+
+    (* NOTE(@leostera): Generate the final assembling of the record value
+
+       {ocaml[
+         ... in
+         Ok { name; age }
+       ]}
+    *)
+    let record_expr =
+      let fields =
+        List.map
+          (fun field ->
+            let value = Ast.evar ~loc field.pld_name.txt in
+            let field = Longident.parse field.pld_name.txt |> var ~ctxt in
+            (field, value))
+          labels
+      in
+      let record = Ast.pexp_record ~loc fields None in
+      final_expr record
+    in
+
+    (* NOTE(@leostera): Generate the placeholder values for a list of fields:
+
+       {ocaml[
+         let name = ref None in
+         let age = ref None in
+         ...
+       ]}
+    *)
+    let field_value_holders body =
+      List.fold_left
+        (fun last field ->
+          let field = Ast.(pvar ~loc field.pld_name.txt) in
+          [%expr
+            let [%p field] = ref None in
+            [%e last]])
+        body labels
+    in
+
+    (* NOTE(@leostera): Generate the placeholder values for a list of fields:
+
+       {ocaml[
+         let name = ref None in
+         let age = ref None in
+         ...
+       ]}
+    *)
+    let field_value_unwrapping body =
+      List.fold_left
+        (fun last field ->
+          let field_var = Ast.(evar ~loc field.pld_name.txt) in
+          let field_pat = Ast.(pvar ~loc field.pld_name.txt) in
+          let missing_msg =
+            Ast.estring ~loc
+              (Format.sprintf "missing field %S" field.pld_name.txt)
+          in
+          [%expr
+            let* [%p field_pat] =
+              Option.to_result ~none:(`Msg [%e missing_msg]) ![%e field_var]
+            in
+            [%e last]])
+        body labels
+    in
+
+    (* NOTE(@leostera): creates the visito from strings/ints to polymorphic
+       variants for each field
+
+       {ocaml[
+          Visitor.make
+            ~visit_string:(fun _ctx str ->
+              match str with
+              | "name" -> Ok `name
+              | "age" -> Ok `age
+              | _ -> Error `invalid_field_type)
+            ~visit_int:(fun _ctx int ->
+              match int with
+              | 0 -> Ok `name
+              | 1 -> Ok `age
+              | _ -> Error `invalid_field_type)
+            ()
+       ]}
+    *)
+    let field_visitor next =
+      let visit_string =
+        let cases =
+          List.map
+            (fun field ->
+              let lhs = Ast.pstring ~loc field.pld_name.txt in
+              let rhs =
+                let tag = Ast.pexp_variant ~loc field.pld_name.txt None in
+                [%expr Ok [%e tag]]
+              in
+              Ast.case ~lhs ~rhs ~guard:None)
+            labels
+          @ [
+              Ast.case ~lhs:(Ast.ppat_any ~loc) ~guard:None
+                ~rhs:[%expr Error `invalid_tag];
+            ]
+        in
+        let body = Ast.pexp_match ~loc [%expr str] cases in
+        [%expr fun _ctx str -> [%e body]]
+      in
+
+      let visit_int =
+        let cases =
+          List.mapi
+            (fun idx field ->
+              let lhs = Ast.pint ~loc idx in
+              let rhs =
+                let tag = Ast.pexp_variant ~loc field.pld_name.txt None in
+                [%expr Ok [%e tag]]
+              in
+              Ast.case ~lhs ~rhs ~guard:None)
+            labels
+          @ [
+              Ast.case ~lhs:(Ast.ppat_any ~loc) ~guard:None
+                ~rhs:[%expr Error `invalid_tag];
+            ]
+        in
+        let body = Ast.pexp_match ~loc [%expr str] cases in
+        [%expr fun _ctx str -> [%e body]]
+      in
+
+      [%expr
+        let field_visitor =
+          let visit_string = [%e visit_string] in
+          let visit_int = [%e visit_int] in
+          Visitor.make ~visit_string ~visit_int ()
+        in
+        [%e next]]
+    in
+
+    let declare_read_fields next =
+      let cases =
+        List.mapi
+          (fun _idx (label : Parsetree.label_declaration) ->
+            let lhs =
+              let tag = Ast.ppat_variant ~loc label.pld_name.txt None in
+              Ast.ppat_construct ~loc
+                Longident.(parse "Some" |> var ~ctxt)
+                (Some tag)
+            in
+            let rhs =
+              let field_name = Ast.estring ~loc label.pld_name.txt in
+              let field_var = Ast.(evar ~loc label.pld_name.txt) in
+              let deserializer = deserializer_for_type ~ctxt label.pld_type in
+              let assign =
+                Ast.(
+                  pexp_apply ~loc
+                    (pexp_ident ~loc (var ~ctxt (Longident.parse ":=")))
+                    [ (Nolabel, field_var); (Nolabel, [%expr Some v]) ])
+              in
+              [%expr
+                let* v = field ctx [%e field_name] [%e deserializer] in
+                [%e assign];
+                read_fields ()]
+            in
+            Ast.case ~lhs ~guard:None ~rhs)
+          labels
+        @ [
+            Ast.case
+              ~lhs:
+                (Ast.ppat_construct ~loc
+                   Longident.(parse "None" |> var ~ctxt)
+                   None)
+              ~guard:None ~rhs:[%expr Ok ()];
+          ]
+      in
+
+      let tag_match = Ast.pexp_match ~loc [%expr tag] cases in
+
+      [%expr
+        let rec read_fields () =
+          let* tag = next_field ctx field_visitor in
+          [%e tag_match]
+        in
+        [%e next]]
+    in
+
+    let call_read_fields next =
+      [%expr
+        let* () = read_fields () in
+        [%e next]]
+    in
+
+    field_visitor
+    (* declare all the optional references *)
+    @@ field_value_holders
+    (* declare our recursive function for consuming fields *)
+    @@ declare_read_fields
+    (* here's where the magic happens *)
+    @@ call_read_fields
+    (* unwrap all the boxes *)
+    @@ field_value_unwrapping
+    (* build the record *)
+    @@ record_expr
+end
+
 let gen_serialize_variant_impl ~ctxt ptype_name cstr_declarations =
   let loc = loc ~ctxt in
   let type_name = Ast.estring ~loc ptype_name.txt in
@@ -143,47 +415,17 @@ let gen_serialize_variant_impl ~ctxt ptype_name cstr_declarations =
     (* NOTE(@leostera): deserialize a record_variant *)
     | Pcstr_record labels ->
         let field_count = Ast.eint ~loc (List.length labels) in
-        let record_expr =
-          let fields =
-            List.map
-              (fun field ->
-                let value = Ast.evar ~loc field.pld_name.txt in
-                let field = Longident.parse field.pld_name.txt |> var ~ctxt in
-                (field, value))
-              labels
-          in
-          let record = Ast.pexp_record ~loc fields None in
+        let body =
+          Record_deserializer.deserialize_with_unordered_fields ~ctxt labels
+          @@ fun record ->
           let cstr = Ast.pexp_construct ~loc name (Some record) in
           [%expr Ok [%e cstr]]
-        in
-
-        let fields =
-          List.map
-            (fun field ->
-              let field_name = Ast.estring ~loc field.pld_name.txt in
-              let deserializer = deserializer_for_type ~ctxt field.pld_type in
-              let de_expr =
-                [%expr field ctx [%e field_name] [%e deserializer]]
-              in
-              let field_name = field.pld_name.txt in
-              (field_name, de_expr))
-            (List.rev labels)
-        in
-
-        let fields =
-          List.fold_left
-            (fun last (field, expr) ->
-              let field = Ast.(pvar ~loc field) in
-              [%expr
-                let* [%p field] = [%e expr] in
-                [%e last]])
-            record_expr fields
         in
 
         [%expr
           record_variant ctx [%e field_count] (fun ~size ctx ->
               ignore size;
-              [%e fields])]
+              [%e body])]
   in
 
   let tag_dispatch =
@@ -233,41 +475,13 @@ let gen_serialize_record_impl ~ctxt ptype_name label_declarations =
   let type_name = Ast.estring ~loc ptype_name.txt in
   let field_count = Ast.eint ~loc (List.length label_declarations) in
 
-  let record_expr =
-    let fields =
-      List.map
-        (fun field ->
-          let value = Ast.evar ~loc field.pld_name.txt in
-          let field = Longident.parse field.pld_name.txt |> var ~ctxt in
-          (field, value))
-        label_declarations
-    in
-    let record = Ast.pexp_record ~loc fields None in
-    [%expr Ok [%e record]]
+  let body =
+    Record_deserializer.deserialize_with_unordered_fields ~ctxt
+      label_declarations
+    @@ fun record -> [%expr Ok [%e record]]
   in
 
-  let fields =
-    List.map
-      (fun field ->
-        let field_name = Ast.estring ~loc field.pld_name.txt in
-        let deserializer = deserializer_for_type ~ctxt field.pld_type in
-        let de_expr = [%expr field ctx [%e field_name] [%e deserializer]] in
-        let field_name = field.pld_name.txt in
-        (field_name, de_expr))
-      (List.rev label_declarations)
-  in
-
-  let fields =
-    List.fold_left
-      (fun last (field, expr) ->
-        let field = Ast.(pvar ~loc field) in
-        [%expr
-          let* [%p field] = [%e expr] in
-          [%e last]])
-      record_expr fields
-  in
-
-  [%expr record ctx [%e type_name] [%e field_count] (fun ctx -> [%e fields])]
+  [%expr record ctx [%e type_name] [%e field_count] (fun ctx -> [%e body])]
 
 let gen_serialize_impl ~ctxt type_decl =
   let loc = loc ~ctxt in

--- a/serde/serde.ml
+++ b/serde/serde.ml
@@ -463,6 +463,12 @@ module rec De_base : sig
       ('value, state) t ->
       ('value, error) result
 
+    val deserialize_key :
+      state ctx ->
+      state ->
+      ('value, state, 'tag) visitor ->
+      ('value option, error) result
+
     val deserialize_identifier :
       state ctx ->
       state ->
@@ -551,6 +557,12 @@ end = struct
       name:string ->
       ('value, state) t ->
       ('value, error) result
+
+    val deserialize_key :
+      state ctx ->
+      state ->
+      ('value, state, 'tag) visitor ->
+      ('value option, error) result
 
     val deserialize_identifier :
       state ctx ->
@@ -660,6 +672,10 @@ module De = struct
       (((module D), state) as ctx : state ctx) size de =
     D.deserialize_record_variant ctx state ~size de
 
+  let deserialize_key (type state) (((module D), state) as ctx : state ctx)
+      visitor =
+    D.deserialize_key ctx state visitor
+
   let deserialize_identifier (type state)
       (((module D), state) as ctx : state ctx) visitor =
     D.deserialize_identifier ctx state visitor
@@ -692,6 +708,7 @@ module De = struct
   let record_variant ctx size de = deserialize_record_variant ctx size de
   let element ctx de = deserialize_element ctx de
   let field ctx name de = deserialize_field ctx name de
+  let next_field ctx visitor = deserialize_key ctx visitor
   let option de ctx = deserialize_option ctx de
   let float ctx = deserialize_float ctx
 

--- a/serde/serde_test.ml
+++ b/serde/serde_test.ml
@@ -170,6 +170,8 @@ module Serde_bin = struct
     let deserialize_field self _state ~name:_ element =
       De.deserialize self element
 
+    let deserialize_key _self _state _visitor = Ok None
+
     let deserialize_identifier self _state visitor =
       let* str = De.deserialize_int31 self in
       Visitor.visit_int self visitor str


### PR DESCRIPTION
This PR adds a new `deserialize_key` feature to read the name of a field before deserializing the actual field value.

This helps implement manual and derived unordered-field deserializer and closes #10.

We also implemented support for the JSON data format, and extend our drivers to generate unordered-field by default.