### PR TITLE
fix: do not leak let bind and force Stdlib usage

### DIFF
--- a/derive/de.ml
+++ b/derive/de.ml
@@ -212,7 +212,9 @@ module Record_deserializer = struct
           | `required ->
               [%expr
                 let* [%p field_pat] =
-                  Option.to_result ~none:(`Msg [%e missing_msg]) ![%e field_var]
+                  Stdlib.Option.to_result
+                    ~none:(`Msg [%e missing_msg])
+                    ![%e field_var]
                 in
                 [%e last]]
           | `optional ->
@@ -791,13 +793,13 @@ let gen_deserialize_impl ~ctxt type_decl =
   in
   [%stri
     let [%p deserializer_name] =
-      let ( let* ) = Result.bind in
+      let ( let* ) = Stdlib.Result.bind in
       let _ = ( let* ) in
       Serde.De.(fun ctx -> [%e body])]
 
 let generate_impl ~ctxt (_rec_flag, type_declarations) =
   let loc = loc ~ctxt in
-  [ [%stri open! Serde]; [%stri let ( let* ) = Result.bind] ]
+  [ [%stri open! Serde] ]
   @ List.map (gen_deserialize_impl ~ctxt) type_declarations
 
 let impl_generator = Deriving.Generator.V2.make_noarg generate_impl

--- a/derive/ser.ml
+++ b/derive/ser.ml
@@ -364,12 +364,15 @@ let gen_serialize_impl ~ctxt type_decl =
   let serializer_name =
     "serialize_" ^ typename |> var ~ctxt |> Ast.ppat_var ~loc
   in
-  [%stri let [%p serializer_name] = Serde.Ser.(fun t ctx -> [%e body])]
+  [%stri
+    let [%p serializer_name] =
+      let ( let* ) = Stdlib.Result.bind in
+      let _ = ( let* ) in
+      Serde.Ser.(fun t ctx -> [%e body])]
 
 let generate_impl ~ctxt (_rec_flag, type_declarations) =
   let loc = loc ~ctxt in
-  [ [%stri let ( let* ) = Result.bind] ]
-  @ List.map (gen_serialize_impl ~ctxt) type_declarations
+  List.map (gen_serialize_impl ~ctxt) type_declarations
 
 let impl_generator = Deriving.Generator.V2.make_noarg generate_impl
 


### PR DESCRIPTION
Previously, whenever you use serde derive, you leak `let*` binding. Also, if you have something that shadows Option or Result open at the time of using it, you can get an error.